### PR TITLE
chore: Update `css-inline` to `0.10`

### DIFF
--- a/pco_mail/base.py
+++ b/pco_mail/base.py
@@ -312,7 +312,7 @@ def _get_reminder_html_mail(
         plan=plan_title,
         link=pco_link,
     )
-    inliner = css_inline.CSSInliner(remove_style_tags=True)
+    inliner = css_inline.CSSInliner()
     inlined_content = inliner.inline(mail_content)
     entities_content = (
         inlined_content.encode("ascii", "xmlcharrefreplace")
@@ -341,7 +341,7 @@ def _get_votd_html_mail(name):
         location=verse["ref"],
         link=verse["link"],
     )
-    inliner = css_inline.CSSInliner(remove_style_tags=True)
+    inliner = css_inline.CSSInliner()
     inlined_content = inliner.inline(mail_content)
     entities_content = (
         inlined_content.encode("ascii", "xmlcharrefreplace")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests
 types-requests
 yagmail
 jinja2
-css_inline
+css_inline==0.10.1
 pytz
 types-pytz
 # ics


### PR DESCRIPTION
### Summary :memo:

This PR pins `css-inline` to its latest version and updates the usage to reflect the changes in the library.

### Details
_Describe more what you did on changes._
1. Removed `remove_style_tags=True`. This option was removed from `css-inline` and now it removes `style` tags by default.


### Checks
- [ ] Closed #798
- [ ] Tested Changes
- [ ] Stakeholder Approval
